### PR TITLE
Job Rescheduling

### DIFF
--- a/enqueue_test.go
+++ b/enqueue_test.go
@@ -1,171 +1,171 @@
 package que
 
 import (
-    "context"
-    "testing"
-    "time"
+	"context"
+	"testing"
+	"time"
 
-    "github.com/jackc/pgtype"
+	"github.com/jackc/pgtype"
 )
 
 func TestEnqueueOnlyType(t *testing.T) {
-    c := openTestClient(t)
-    defer closePool(c.pool)
+	c := openTestClient(t)
+	defer closePool(c.pool)
 
-    if err := c.Enqueue(&Job{Type: "MyJob"}); err != nil {
-        t.Fatal(err)
-    }
+	if err := c.Enqueue(&Job{Type: "MyJob"}); err != nil {
+		t.Fatal(err)
+	}
 
-    j, err := findOneJob(c.pool)
-    if err != nil {
-        t.Fatal(err)
-    }
+	j, err := findOneJob(c.pool)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-    // check resulting job
-    if j.ID == 0 {
-        t.Errorf("want non-zero ID")
-    }
-    if want := ""; j.Queue != want {
-        t.Errorf("want Queue=%q, got %q", want, j.Queue)
-    }
-    if want := int16(100); j.Priority != want {
-        t.Errorf("want Priority=%d, got %d", want, j.Priority)
-    }
-    if j.RunAt.IsZero() {
-        t.Error("want non-zero RunAt")
-    }
-    if want := "MyJob"; j.Type != want {
-        t.Errorf("want Type=%q, got %q", want, j.Type)
-    }
-    if want, got := "[]", string(j.Args); got != want {
-        t.Errorf("want Args=%s, got %s", want, got)
-    }
-    if want := int32(0); j.ErrorCount != want {
-        t.Errorf("want ErrorCount=%d, got %d", want, j.ErrorCount)
-    }
-    if j.LastError.Status == pgtype.Present {
-        t.Errorf("want no LastError, got %v", j.LastError)
-    }
+	// check resulting job
+	if j.ID == 0 {
+		t.Errorf("want non-zero ID")
+	}
+	if want := ""; j.Queue != want {
+		t.Errorf("want Queue=%q, got %q", want, j.Queue)
+	}
+	if want := int16(100); j.Priority != want {
+		t.Errorf("want Priority=%d, got %d", want, j.Priority)
+	}
+	if j.RunAt.IsZero() {
+		t.Error("want non-zero RunAt")
+	}
+	if want := "MyJob"; j.Type != want {
+		t.Errorf("want Type=%q, got %q", want, j.Type)
+	}
+	if want, got := "[]", string(j.Args); got != want {
+		t.Errorf("want Args=%s, got %s", want, got)
+	}
+	if want := int32(0); j.ErrorCount != want {
+		t.Errorf("want ErrorCount=%d, got %d", want, j.ErrorCount)
+	}
+	if j.LastError.Status == pgtype.Present {
+		t.Errorf("want no LastError, got %v", j.LastError)
+	}
 }
 
 func TestEnqueueWithPriority(t *testing.T) {
-    c := openTestClient(t)
-    defer closePool(c.pool)
+	c := openTestClient(t)
+	defer closePool(c.pool)
 
-    want := int16(99)
-    if err := c.Enqueue(&Job{Type: "MyJob", Priority: want}); err != nil {
-        t.Fatal(err)
-    }
+	want := int16(99)
+	if err := c.Enqueue(&Job{Type: "MyJob", Priority: want}); err != nil {
+		t.Fatal(err)
+	}
 
-    j, err := findOneJob(c.pool)
-    if err != nil {
-        t.Fatal(err)
-    }
+	j, err := findOneJob(c.pool)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-    if j.Priority != want {
-        t.Errorf("want Priority=%d, got %d", want, j.Priority)
-    }
+	if j.Priority != want {
+		t.Errorf("want Priority=%d, got %d", want, j.Priority)
+	}
 }
 
 func TestEnqueueWithRunAt(t *testing.T) {
-    c := openTestClient(t)
-    defer closePool(c.pool)
+	c := openTestClient(t)
+	defer closePool(c.pool)
 
-    want := time.Now().Add(2 * time.Minute)
-    if err := c.Enqueue(&Job{Type: "MyJob", RunAt: want}); err != nil {
-        t.Fatal(err)
-    }
+	want := time.Now().Add(2 * time.Minute)
+	if err := c.Enqueue(&Job{Type: "MyJob", RunAt: want}); err != nil {
+		t.Fatal(err)
+	}
 
-    j, err := findOneJob(c.pool)
-    if err != nil {
-        t.Fatal(err)
-    }
+	j, err := findOneJob(c.pool)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-    // truncate to the microsecond as postgres driver does
-    want = want.Truncate(time.Microsecond)
-    if !want.Equal(j.RunAt) {
-        t.Errorf("want RunAt=%s, got %s", want, j.RunAt)
-    }
+	// truncate to the microsecond as postgres driver does
+	want = want.Truncate(time.Microsecond)
+	if !want.Equal(j.RunAt) {
+		t.Errorf("want RunAt=%s, got %s", want, j.RunAt)
+	}
 }
 
 func TestEnqueueWithArgs(t *testing.T) {
-    c := openTestClient(t)
-    defer closePool(c.pool)
+	c := openTestClient(t)
+	defer closePool(c.pool)
 
-    want := `{"arg1":0, "arg2":"a string"}`
-    if err := c.Enqueue(&Job{Type: "MyJob", Args: []byte(want)}); err != nil {
-        t.Fatal(err)
-    }
+	want := `{"arg1":0, "arg2":"a string"}`
+	if err := c.Enqueue(&Job{Type: "MyJob", Args: []byte(want)}); err != nil {
+		t.Fatal(err)
+	}
 
-    j, err := findOneJob(c.pool)
-    if err != nil {
-        t.Fatal(err)
-    }
+	j, err := findOneJob(c.pool)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-    if got := string(j.Args); got != want {
-        t.Errorf("want Args=%s, got %s", want, got)
-    }
+	if got := string(j.Args); got != want {
+		t.Errorf("want Args=%s, got %s", want, got)
+	}
 }
 
 func TestEnqueueWithQueue(t *testing.T) {
-    c := openTestClient(t)
-    defer closePool(c.pool)
+	c := openTestClient(t)
+	defer closePool(c.pool)
 
-    want := "special-work-queue"
-    if err := c.Enqueue(&Job{Type: "MyJob", Queue: want}); err != nil {
-        t.Fatal(err)
-    }
+	want := "special-work-queue"
+	if err := c.Enqueue(&Job{Type: "MyJob", Queue: want}); err != nil {
+		t.Fatal(err)
+	}
 
-    j, err := findOneJob(c.pool)
-    if err != nil {
-        t.Fatal(err)
-    }
+	j, err := findOneJob(c.pool)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-    if j.Queue != want {
-        t.Errorf("want Queue=%q, got %q", want, j.Queue)
-    }
+	if j.Queue != want {
+		t.Errorf("want Queue=%q, got %q", want, j.Queue)
+	}
 }
 
 func TestEnqueueWithEmptyType(t *testing.T) {
-    c := openTestClient(t)
-    defer closePool(c.pool)
+	c := openTestClient(t)
+	defer closePool(c.pool)
 
-    if err := c.Enqueue(&Job{Type: ""}); err != ErrMissingType {
-        t.Fatalf("want ErrMissingType, got %v", err)
-    }
+	if err := c.Enqueue(&Job{Type: ""}); err != ErrMissingType {
+		t.Fatalf("want ErrMissingType, got %v", err)
+	}
 }
 
 func TestEnqueueInTx(t *testing.T) {
-    c := openTestClient(t)
-    defer closePool(c.pool)
+	c := openTestClient(t)
+	defer closePool(c.pool)
 
-    tx, err := c.pool.Begin(context.Background())
-    if err != nil {
-        t.Fatal(err)
-    }
-    defer tx.Rollback(context.Background())
+	tx, err := c.pool.Begin(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback(context.Background())
 
-    if err = c.EnqueueInTx(&Job{Type: "MyJob"}, tx); err != nil {
-        t.Fatal(err)
-    }
+	if err = c.EnqueueInTx(&Job{Type: "MyJob"}, tx); err != nil {
+		t.Fatal(err)
+	}
 
-    j, err := findOneJob(tx)
-    if err != nil {
-        t.Fatal(err)
-    }
-    if j == nil {
-        t.Fatal("want job, got none")
-    }
+	j, err := findOneJob(tx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if j == nil {
+		t.Fatal("want job, got none")
+	}
 
-    if err = tx.Rollback(context.Background()); err != nil {
-        t.Fatal(err)
-    }
+	if err = tx.Rollback(context.Background()); err != nil {
+		t.Fatal(err)
+	}
 
-    j, err = findOneJob(c.pool)
-    if err != nil {
-        t.Fatal(err)
-    }
-    if j != nil {
-        t.Fatalf("wanted job to be rolled back, got %+v", j)
-    }
+	j, err = findOneJob(c.pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if j != nil {
+		t.Fatalf("wanted job to be rolled back, got %+v", j)
+	}
 }

--- a/que.go
+++ b/que.go
@@ -1,54 +1,55 @@
 package que
 
 import (
-    "context"
-    "errors"
-    "sync"
-    "time"
+	"context"
+	"errors"
+	"sync"
+	"time"
 
-    "github.com/jackc/pgconn"
-    "github.com/jackc/pgtype"
-    "github.com/jackc/pgx/v4"
-    "github.com/jackc/pgx/v4/pgxpool"
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgtype"
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
 )
 
 // Job is a single unit of work for Que to perform.
 type Job struct {
-    // ID is the unique database ID of the Job. It is ignored on job creation.
-    ID int64
+	// ID is the unique database ID of the Job. It is ignored on job creation.
+	ID int64
 
-    // Queue is the name of the queue. It defaults to the empty queue "".
-    Queue string
+	// Queue is the name of the queue. It defaults to the empty queue "".
+	Queue string
 
-    // Priority is the priority of the Job. The default priority is 100, and a
-    // lower number means a higher priority. A priority of 5 would be very
-    // important.
-    Priority int16
+	// Priority is the priority of the Job. The default priority is 100, and a
+	// lower number means a higher priority. A priority of 5 would be very
+	// important.
+	Priority int16
 
-    // RunAt is the time that this job should be executed. It defaults to now(),
-    // meaning the job will execute immediately. Set it to a value in the future
-    // to delay a job's execution.
-    RunAt time.Time
+	// RunAt is the time that this job should be executed. It defaults to now(),
+	// meaning the job will execute immediately. Set it to a value in the future
+	// to delay a job's execution.
+	RunAt time.Time
 
-    // Type corresponds to the Ruby job_class. If you are interoperating with
-    // Ruby, you should pick suitable Ruby class names (such as MyJob).
-    Type string
+	// Type corresponds to the Ruby job_class. If you are interoperating with
+	// Ruby, you should pick suitable Ruby class names (such as MyJob).
+	Type string
 
-    // Args must be the bytes of a valid JSON string
-    Args []byte
+	// Args must be the bytes of a valid JSON string
+	Args []byte
 
-    // ErrorCount is the number of times this job has attempted to run, but
-    // failed with an error. It is ignored on job creation.
-    ErrorCount int32
+	// ErrorCount is the number of times this job has attempted to run, but
+	// failed with an error. It is ignored on job creation.
+	ErrorCount int32
 
-    // LastError is the error message or stack trace from the last time the job
-    // failed. It is ignored on job creation.
-    LastError pgtype.Text
+	// LastError is the error message or stack trace from the last time the job
+	// failed. It is ignored on job creation.
+	LastError pgtype.Text
 
-    mu      sync.Mutex
-    deleted bool
-    pool    *pgxpool.Pool
-    conn    *pgxpool.Conn
+	mu         sync.Mutex
+	finalized  bool
+	reschedule bool
+	pool       *pgxpool.Pool
+	conn       *pgxpool.Conn
 }
 
 // Conn returns the pgx connection that this job is locked to. You may initiate
@@ -57,10 +58,10 @@ type Job struct {
 // unsafe to keep using it. This function will return nil if the Job's
 // connection has already been released with Done().
 func (j *Job) Conn() *pgxpool.Conn {
-    j.mu.Lock()
-    defer j.mu.Unlock()
+	j.mu.Lock()
+	defer j.mu.Unlock()
 
-    return j.conn
+	return j.conn
 }
 
 // Delete marks this job as complete by deleting it form the database.
@@ -68,41 +69,104 @@ func (j *Job) Conn() *pgxpool.Conn {
 // You must also later call Done() to return this job's database connection to
 // the pool.
 func (j *Job) Delete() error {
-    j.mu.Lock()
-    defer j.mu.Unlock()
+	j.mu.Lock()
+	defer j.mu.Unlock()
 
-    if j.deleted {
-        return nil
-    }
+	if j.finalized {
+		return nil
+	}
 
-    _, err := j.conn.Exec(context.Background(), "que_destroy_job", j.Queue, j.Priority, j.RunAt, j.ID)
-    if err != nil {
-        return err
-    }
+	_, err := j.conn.Exec(context.Background(), "que_destroy_job", j.Queue, j.Priority, j.RunAt, j.ID)
+	if err != nil {
+		return err
+	}
 
-    j.deleted = true
-    return nil
+	j.finalized = true
+	return nil
+}
+
+// Update job in database.
+//
+// You must also later call Done() to return this job's database connection to
+// the pool.
+func (j *Job) Update() error {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	if j.finalized {
+		return nil
+	}
+
+	if j.Type == "" {
+		return ErrMissingType
+	}
+
+	_, err := j.conn.Exec(context.Background(), "que_update_job",
+		j.ID,
+		j.Priority,
+		j.RunAt,
+		j.Type,
+		j.Args,
+		j.ErrorCount,
+		j.LastError,
+		j.Queue,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	j.finalized = true
+	return nil
+}
+
+// Finalize either updates or deletes this job
+// from the DB.
+//
+// You must also later call Done() to return this job's database connection to
+// the pool.
+func (j *Job) Finalize() error {
+	if j.reschedule {
+		return j.Update()
+	}
+	return j.Delete()
 }
 
 // Done releases the Postgres advisory lock on the job and returns the database
 // connection to the pool.
 func (j *Job) Done() {
-    j.mu.Lock()
-    defer j.mu.Unlock()
+	j.mu.Lock()
+	defer j.mu.Unlock()
 
-    if j.conn == nil || j.pool == nil {
-        // already marked as done
-        return
-    }
+	if j.conn == nil || j.pool == nil {
+		// already marked as done
+		return
+	}
 
-    var ok bool
-    // Swallow this error because we don't want an unlock failure to cause work to
-    // stop.
-    _ = j.conn.QueryRow(context.Background(), "que_unlock_job", j.ID).Scan(&ok)
+	var ok bool
+	// Swallow this error because we don't want an unlock failure to cause work to
+	// stop.
+	_ = j.conn.QueryRow(context.Background(), "que_unlock_job", j.ID).Scan(&ok)
 
-    j.conn.Release()
-    j.pool = nil
-    j.conn = nil
+	j.conn.Release()
+	j.pool = nil
+	j.conn = nil
+}
+
+// Reschedule this job for a later time
+func (j *Job) Reschedule(runAt time.Time) {
+	j.RunAt = runAt
+	j.reschedule = true
+}
+
+// ResetError zeros out the error count and removes
+// the last error from this job instance.
+//
+// Use this while rescheduling jobs that might have errors.
+func (j *Job) ResetError() {
+	j.ErrorCount = 0
+	j.LastError.Set(nil)
+
 }
 
 // Error marks the job as failed and schedules it to be reworked. An error
@@ -112,27 +176,27 @@ func (j *Job) Done() {
 // You must also later call Done() to return this job's database connection to
 // the pool.
 func (j *Job) Error(msg string) error {
-    errorCount := j.ErrorCount + 1
-    delay := intPow(int(errorCount), 4) + 3 // TODO: configurable delay
+	errorCount := j.ErrorCount + 1
+	delay := intPow(int(errorCount), 4) + 3 // TODO: configurable delay
 
-    _, err := j.conn.Exec(context.Background(), "que_set_error", errorCount, delay, msg, j.Queue, j.Priority, j.RunAt, j.ID)
-    if err != nil {
-        return err
-    }
-    return nil
+	_, err := j.conn.Exec(context.Background(), "que_set_error", errorCount, delay, msg, j.Queue, j.Priority, j.RunAt, j.ID)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // Client is a Que client that can add jobs to the queue and remove jobs from
 // the queue.
 type Client struct {
-    pool *pgxpool.Pool
+	pool *pgxpool.Pool
 
-    // TODO: add a way to specify default queueing options
+	// TODO: add a way to specify default queueing options
 }
 
 // NewClient creates a new Client that uses the pgx pool.
 func NewClient(pool *pgxpool.Pool) *Client {
-    return &Client{pool: pool}
+	return &Client{pool: pool}
 }
 
 // ErrMissingType is returned when you attempt to enqueue a job with no Type
@@ -141,7 +205,7 @@ var ErrMissingType = errors.New("job type must be specified")
 
 // Enqueue adds a job to the queue.
 func (c *Client) Enqueue(j *Job) error {
-    return execEnqueue(j, c.pool)
+	return execEnqueue(j, c.pool)
 }
 
 // EnqueueInTx adds a job to the queue within the scope of the transaction tx.
@@ -151,54 +215,54 @@ func (c *Client) Enqueue(j *Job) error {
 // It is the caller's responsibility to Commit or Rollback the transaction after
 // this function is called.
 func (c *Client) EnqueueInTx(j *Job, tx pgx.Tx) error {
-    return execEnqueue(j, tx)
+	return execEnqueue(j, tx)
 }
 
 func execEnqueue(j *Job, q queryable) error {
-    if j.Type == "" {
-        return ErrMissingType
-    }
+	if j.Type == "" {
+		return ErrMissingType
+	}
 
-    queue := &pgtype.Text{
-        String: j.Queue,
-        Status: pgtype.Null,
-    }
-    if j.Queue != "" {
-        queue.Status = pgtype.Present
-    }
+	queue := &pgtype.Text{
+		String: j.Queue,
+		Status: pgtype.Null,
+	}
+	if j.Queue != "" {
+		queue.Status = pgtype.Present
+	}
 
-    priority := &pgtype.Int2{
-        Int:    j.Priority,
-        Status: pgtype.Null,
-    }
-    if j.Priority != 0 {
-        priority.Status = pgtype.Present
-    }
+	priority := &pgtype.Int2{
+		Int:    j.Priority,
+		Status: pgtype.Null,
+	}
+	if j.Priority != 0 {
+		priority.Status = pgtype.Present
+	}
 
-    runAt := &pgtype.Timestamptz{
-        Time:   j.RunAt,
-        Status: pgtype.Null,
-    }
-    if !j.RunAt.IsZero() {
-        runAt.Status = pgtype.Present
-    }
+	runAt := &pgtype.Timestamptz{
+		Time:   j.RunAt,
+		Status: pgtype.Null,
+	}
+	if !j.RunAt.IsZero() {
+		runAt.Status = pgtype.Present
+	}
 
-    args := &pgtype.Bytea{
-        Bytes:  j.Args,
-        Status: pgtype.Null,
-    }
-    if len(j.Args) != 0 {
-        args.Status = pgtype.Present
-    }
+	args := &pgtype.Bytea{
+		Bytes:  j.Args,
+		Status: pgtype.Null,
+	}
+	if len(j.Args) != 0 {
+		args.Status = pgtype.Present
+	}
 
-    _, err := q.Exec(context.Background(), "que_insert_job", queue, priority, runAt, j.Type, args)
-    return err
+	_, err := q.Exec(context.Background(), "que_insert_job", queue, priority, runAt, j.Type, args)
+	return err
 }
 
 type queryable interface {
-    Exec(ctx context.Context, sql string, arguments ...interface{}) (commandTag pgconn.CommandTag, err error)
-    Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
-    QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row
+	Exec(ctx context.Context, sql string, arguments ...interface{}) (commandTag pgconn.CommandTag, err error)
+	Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row
 }
 
 // Maximum number of loop iterations in LockJob before giving up.  This is to
@@ -226,70 +290,76 @@ var ErrAgain = errors.New("maximum number of LockJob attempts reached")
 // After the Job has been worked, you must call either Done() or Error() on it
 // in order to return the database connection to the pool and remove the lock.
 func (c *Client) LockJob(queue string) (*Job, error) {
-    conn, err := c.pool.Acquire(context.Background())
-    if err != nil {
-        return nil, err
-    }
-    j := Job{pool: c.pool, conn: conn}
+	conn, err := c.pool.Acquire(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	j := Job{pool: c.pool, conn: conn}
 
-    for i := 0; i < maxLockJobAttempts; i++ {
-        err = conn.QueryRow(context.Background(), "que_lock_job", queue).Scan(
-            &j.Queue,
-            &j.Priority,
-            &j.RunAt,
-            &j.ID,
-            &j.Type,
-            &j.Args,
-            &j.ErrorCount,
-        )
-        if err != nil {
-            j.conn.Release()
-            if err == pgx.ErrNoRows {
-                return nil, nil
-            }
-            return nil, err
-        }
-        // Deal with race condition. Explanation from the Ruby Que gem:
-        //
-        // Edge case: It's possible for the lock_job query to have
-        // grabbed a job that's already been worked, if it took its MVCC
-        // snapshot while the job was processing, but didn't attempt the
-        // advisory lock until it was finished. Since we have the lock, a
-        // previous worker would have deleted it by now, so we just
-        // double check that it still exists before working it.
-        //
-        // Note that there is currently no spec for this behavior, since
-        // I'm not sure how to reliably commit a transaction that deletes
-        // the job in a separate thread between lock_job and check_job.
-        var ok bool
-        err = conn.QueryRow(context.Background(), "que_check_job", j.Queue, j.Priority, j.RunAt, j.ID).Scan(&ok)
-        if err == nil {
-            return &j, nil
-        } else if err == pgx.ErrNoRows {
-            // Encountered job race condition; start over from the beginning.
-            // We're still holding the advisory lock, though, so we need to
-            // release it before resuming.  Otherwise we leak the lock,
-            // eventually causing the server to run out of locks.
-            //
-            // Also swallow the possible error, exactly like in Done.
-            _ = conn.QueryRow(context.Background(), "que_unlock_job", j.ID).Scan(&ok)
-            continue
-        } else {
-            j.conn.Release()
-            return nil, err
-        }
-    }
-    j.conn.Release()
-    return nil, ErrAgain
+	for i := 0; i < maxLockJobAttempts; i++ {
+
+		err = conn.QueryRow(context.Background(), "que_lock_job", queue).Scan(
+			&j.Queue,
+			&j.Priority,
+			&j.RunAt,
+			&j.ID,
+			&j.Type,
+			&j.Args,
+			&j.ErrorCount,
+			&j.LastError,
+		)
+		// set the last error
+		// j.LastError.Set(lastError)
+
+		if err != nil {
+			j.conn.Release()
+			if err == pgx.ErrNoRows {
+				return nil, nil
+			}
+			return nil, err
+		}
+		// Deal with race condition. Explanation from the Ruby Que gem:
+		//
+		// Edge case: It's possible for the lock_job query to have
+		// grabbed a job that's already been worked, if it took its MVCC
+		// snapshot while the job was processing, but didn't attempt the
+		// advisory lock until it was finished. Since we have the lock, a
+		// previous worker would have deleted it by now, so we just
+		// double check that it still exists before working it.
+		//
+		// Note that there is currently no spec for this behavior, since
+		// I'm not sure how to reliably commit a transaction that deletes
+		// the job in a separate thread between lock_job and check_job.
+		var ok bool
+		err = conn.QueryRow(context.Background(), "que_check_job", j.Queue, j.Priority, j.RunAt, j.ID).Scan(&ok)
+		if err == nil {
+			return &j, nil
+		} else if err == pgx.ErrNoRows {
+			// Encountered job race condition; start over from the beginning.
+			// We're still holding the advisory lock, though, so we need to
+			// release it before resuming.  Otherwise we leak the lock,
+			// eventually causing the server to run out of locks.
+			//
+			// Also swallow the possible error, exactly like in Done.
+			_ = conn.QueryRow(context.Background(), "que_unlock_job", j.ID).Scan(&ok)
+			continue
+		} else {
+			j.conn.Release()
+			return nil, err
+		}
+	}
+	j.conn.Release()
+	return nil, ErrAgain
 }
 
 var preparedStatements = map[string]string{
-    "que_check_job":   sqlCheckJob,
-    "que_destroy_job": sqlDeleteJob,
-    "que_insert_job":  sqlInsertJob,
-    "que_lock_job":    sqlLockJob,
-    "que_set_error":   sqlSetError,
-    "que_unlock_job":  sqlUnlockJob,
+	"que_check_job":   sqlCheckJob,
+	"que_destroy_job": sqlDeleteJob,
+	"que_insert_job":  sqlInsertJob,
+	"que_update_job":  sqlUpdateJob,
+	"que_lock_job":    sqlLockJob,
+	"que_set_error":   sqlSetError,
+	"que_unlock_job":  sqlUnlockJob,
 }
 
 // PrepareStatements prepares the required statements to run que on the provided
@@ -297,13 +367,13 @@ var preparedStatements = map[string]string{
 // *pgx.ConnPool. Every connection used by que must have the statements prepared
 // ahead of time.
 func PrepareStatements(ctx context.Context, conn *pgx.Conn) error {
-    return PrepareStatementsWithPreparer(ctx, conn)
+	return PrepareStatementsWithPreparer(ctx, conn)
 }
 
 // Preparer defines the interface for types that support preparing
 // statements. This includes all of *pgx.ConnPool, *pgx.Conn, and *pgx.Tx
 type Preparer interface {
-    Prepare(ctx context.Context, name, sql string) (sd *pgconn.StatementDescription, err error)
+	Prepare(ctx context.Context, name, sql string) (sd *pgconn.StatementDescription, err error)
 }
 
 // PrepareStatementsWithPreparer prepares the required statements to run que on
@@ -311,10 +381,10 @@ type Preparer interface {
 // *pgx.ConnPool after it is created, or on a *pg.Tx. Every connection used by
 // que must have the statements prepared ahead of time.
 func PrepareStatementsWithPreparer(ctx context.Context, p Preparer) error {
-    for name, sql := range preparedStatements {
-        if _, err := p.Prepare(ctx, name, sql); err != nil {
-            return err
-        }
-    }
-    return nil
+	for name, sql := range preparedStatements {
+		if _, err := p.Prepare(ctx, name, sql); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/que_test.go
+++ b/que_test.go
@@ -1,62 +1,62 @@
 package que
 
 import (
-    "context"
-    "testing"
+	"context"
+	"testing"
 
-    "github.com/jackc/pgx/v4"
-    "github.com/jackc/pgx/v4/pgxpool"
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
 )
 
 var testConnConfig, _ = pgx.ParseConfig("postgres://postgres:postgres@localhost/que_go_test")
 
 func openTestClientMaxConns(t testing.TB, maxConnections int32) *Client {
-    connPoolConfig, err := pgxpool.ParseConfig(testConnConfig.ConnString())
-    if err != nil {
-        t.Fatal(err)
-    }
-    connPoolConfig.MaxConns = maxConnections
-    connPoolConfig.AfterConnect = PrepareStatements
-    pool, err := pgxpool.ConnectConfig(context.Background(), connPoolConfig)
-    if err != nil {
-        t.Fatal(err)
-    }
-    if _, err := pool.Exec(context.Background(), "TRUNCATE TABLE que_jobs"); err != nil {
-        panic(err)
-    }
+	connPoolConfig, err := pgxpool.ParseConfig(testConnConfig.ConnString())
+	if err != nil {
+		t.Fatal(err)
+	}
+	connPoolConfig.MaxConns = maxConnections
+	connPoolConfig.AfterConnect = PrepareStatements
+	pool, err := pgxpool.ConnectConfig(context.Background(), connPoolConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(context.Background(), "TRUNCATE TABLE que_jobs"); err != nil {
+		panic(err)
+	}
 
-    return NewClient(pool)
+	return NewClient(pool)
 }
 
 func openTestClient(t testing.TB) *Client {
-    return openTestClientMaxConns(t, 5)
+	return openTestClientMaxConns(t, 5)
 }
 
 func closePool(pool *pgxpool.Pool) {
-    pool.Close()
+	pool.Close()
 }
 
 func findOneJob(q queryable) (*Job, error) {
-    findSQL := `
+	findSQL := `
 	SELECT priority, run_at, job_id, job_class, args, error_count, last_error, queue
 	FROM que_jobs LIMIT 1`
 
-    j := &Job{}
-    err := q.QueryRow(context.Background(), findSQL).Scan(
-        &j.Priority,
-        &j.RunAt,
-        &j.ID,
-        &j.Type,
-        &j.Args,
-        &j.ErrorCount,
-        &j.LastError,
-        &j.Queue,
-    )
-    if err == pgx.ErrNoRows {
-        return nil, nil
-    }
-    if err != nil {
-        return nil, err
-    }
-    return j, nil
+	j := &Job{}
+	err := q.QueryRow(context.Background(), findSQL).Scan(
+		&j.Priority,
+		&j.RunAt,
+		&j.ID,
+		&j.Type,
+		&j.Args,
+		&j.ErrorCount,
+		&j.LastError,
+		&j.Queue,
+	)
+	if err == pgx.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return j, nil
 }

--- a/sql.go
+++ b/sql.go
@@ -54,7 +54,7 @@ WITH RECURSIVE jobs AS (
     ) AS t1
   )
 )
-SELECT queue, priority, run_at, job_id, job_class, args, error_count
+SELECT queue, priority, run_at, job_id, job_class, args, error_count, last_error
 FROM jobs
 WHERE locked
 LIMIT 1
@@ -89,6 +89,20 @@ INSERT INTO que_jobs
 (queue, priority, run_at, job_class, args)
 VALUES
 (coalesce($1::text, ''::text), coalesce($2::smallint, 100::smallint), coalesce($3::timestamptz, now()::timestamptz), $4::text, coalesce($5::json, '[]'::json))
+`
+
+	sqlUpdateJob = `
+UPDATE que_jobs
+SET
+    priority    = $2::smallint,
+    run_at      = $3::timestamptz,
+    job_class   = $4::text,
+    args        = coalesce($5::json, '[]'::json),
+    error_count = $6::integer,
+    last_error  = $7::text,
+    queue       = $8::text
+
+ WHERE job_id   = $1::bigint
 `
 
 	sqlDeleteJob = `

--- a/work_test.go
+++ b/work_test.go
@@ -686,8 +686,10 @@ func TestJobUpdate(t *testing.T) {
 	if string(j.Args) != string(j2.Args) {
 		t.Fatal("expected updated job with new args")
 	}
-
-	if j.RunAt.UTC() != j2.RunAt.UTC() {
+	// use epoch seconds to compare, since we might've
+	// ended up with a monotonic date or extra precission
+	// on the milliseconds
+	if j.RunAt.Unix() != j2.RunAt.Unix() {
 		t.Fatal("expected updated job with new runAt")
 	}
 
@@ -765,8 +767,10 @@ func TestJobErrorUpdate(t *testing.T) {
 	if j3.LastError.Status != pgtype.Null {
 		t.Fatal("expected updated job with no last error")
 	}
-
-	if j2.RunAt.UTC() != j3.RunAt.UTC() {
+	// use epoch seconds to compare, since we might've
+	// ended up with a monotonic date or extra precission
+	// on the milliseconds
+	if j2.RunAt.Unix() != j3.RunAt.Unix() {
 		t.Fatal("expected updated job with new runAt")
 	}
 

--- a/work_test.go
+++ b/work_test.go
@@ -668,9 +668,6 @@ func TestJobUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fmt.Printf("j: %+v\n", j)
-	fmt.Printf("j2: %+v\n", j2)
-
 	if j2 == nil {
 		t.Fatal("wanted updated job, got none")
 	}
@@ -755,9 +752,6 @@ func TestJobErrorUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	fmt.Printf("j2: %+v\n", j2)
-	fmt.Printf("j3: %+v\n", j3)
 
 	// error count should be 0 and lasterror null
 	if j3.ErrorCount != 0 {

--- a/work_test.go
+++ b/work_test.go
@@ -664,11 +664,12 @@ func TestJobUpdate(t *testing.T) {
 	j.Done()
 
 	j2, err := findOneJob(c.pool)
-	defer j2.Done()
-
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	fmt.Printf("j: %+v\n", j)
+	fmt.Printf("j2: %+v\n", j2)
 
 	if j2 == nil {
 		t.Fatal("wanted updated job, got none")
@@ -719,7 +720,7 @@ func TestJobErrorUpdate(t *testing.T) {
 
 	// delay so lock job picks
 	// up the previous job
-	time.Sleep(4 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	// use lock job here so we pick up
 	// the job.pool and conn for the update
@@ -749,11 +750,12 @@ func TestJobErrorUpdate(t *testing.T) {
 	j2.Done()
 
 	j3, err := findOneJob(c.pool)
-	defer j3.Done()
-
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	fmt.Printf("j2: %+v\n", j2)
+	fmt.Printf("j3: %+v\n", j3)
 
 	// error count should be 0 and lasterror null
 	if j3.ErrorCount != 0 {

--- a/work_test.go
+++ b/work_test.go
@@ -1,634 +1,771 @@
 package que
 
 import (
-    "context"
-    "fmt"
-    "sync"
-    "testing"
-    "time"
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
 
-    "github.com/jackc/pgtype"
-    "github.com/jackc/pgx/v4"
+	"github.com/jackc/pgtype"
+	"github.com/jackc/pgx/v4"
 )
 
 func TestLockJob(t *testing.T) {
-    c := openTestClient(t)
-    defer closePool(c.pool)
+	c := openTestClient(t)
+	defer closePool(c.pool)
 
-    if err := c.Enqueue(&Job{Type: "MyJob"}); err != nil {
-        t.Fatal(err)
-    }
+	if err := c.Enqueue(&Job{Type: "MyJob"}); err != nil {
+		t.Fatal(err)
+	}
 
-    j, err := c.LockJob("")
-    if err != nil {
-        t.Fatal(err)
-    }
+	j, err := c.LockJob("")
+	if err != nil {
+		t.Fatal(err)
+	}
 
-    if j.conn == nil {
-        t.Fatal("want non-nil conn on locked Job")
-    }
-    if j.pool == nil {
-        t.Fatal("want non-nil pool on locked Job")
-    }
-    defer j.Done()
+	if j.conn == nil {
+		t.Fatal("want non-nil conn on locked Job")
+	}
+	if j.pool == nil {
+		t.Fatal("want non-nil pool on locked Job")
+	}
+	defer j.Done()
 
-    // check values of returned Job
-    if j.ID == 0 {
-        t.Errorf("want non-zero ID")
-    }
-    if want := ""; j.Queue != want {
-        t.Errorf("want Queue=%q, got %q", want, j.Queue)
-    }
-    if want := int16(100); j.Priority != want {
-        t.Errorf("want Priority=%d, got %d", want, j.Priority)
-    }
-    if j.RunAt.IsZero() {
-        t.Error("want non-zero RunAt")
-    }
-    if want := "MyJob"; j.Type != want {
-        t.Errorf("want Type=%q, got %q", want, j.Type)
-    }
-    if want, got := "[]", string(j.Args); got != want {
-        t.Errorf("want Args=%s, got %s", want, got)
-    }
-    if want := int32(0); j.ErrorCount != want {
-        t.Errorf("want ErrorCount=%d, got %d", want, j.ErrorCount)
-    }
-    if j.LastError.Status == pgtype.Present {
-        t.Errorf("want no LastError, got %v", j.LastError)
-    }
+	// check values of returned Job
+	if j.ID == 0 {
+		t.Errorf("want non-zero ID")
+	}
+	if want := ""; j.Queue != want {
+		t.Errorf("want Queue=%q, got %q", want, j.Queue)
+	}
+	if want := int16(100); j.Priority != want {
+		t.Errorf("want Priority=%d, got %d", want, j.Priority)
+	}
+	if j.RunAt.IsZero() {
+		t.Error("want non-zero RunAt")
+	}
+	if want := "MyJob"; j.Type != want {
+		t.Errorf("want Type=%q, got %q", want, j.Type)
+	}
+	if want, got := "[]", string(j.Args); got != want {
+		t.Errorf("want Args=%s, got %s", want, got)
+	}
+	if want := int32(0); j.ErrorCount != want {
+		t.Errorf("want ErrorCount=%d, got %d", want, j.ErrorCount)
+	}
+	if j.LastError.Status == pgtype.Present {
+		t.Errorf("want no LastError, got %v", j.LastError)
+	}
 
-    // check for advisory lock
-    var count int64
-    query := "SELECT count(*) FROM pg_locks WHERE locktype=$1 AND objid=$2::bigint"
-    if err = j.pool.QueryRow(context.Background(), query, "advisory", j.ID).Scan(&count); err != nil {
-        t.Fatal(err)
-    }
-    if count != 1 {
-        t.Errorf("want 1 advisory lock, got %d", count)
-    }
+	// check for advisory lock
+	var count int64
+	query := "SELECT count(*) FROM pg_locks WHERE locktype=$1 AND objid=$2::bigint"
+	if err = j.pool.QueryRow(context.Background(), query, "advisory", j.ID).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Errorf("want 1 advisory lock, got %d", count)
+	}
 
-    // make sure conn was checked out of pool
-    stat := c.pool.Stat()
-    total, available := stat.TotalConns(), stat.IdleConns()
-    if want := total - 1; available != want {
-        t.Errorf("want available=%d, got %d", want, available)
-    }
+	// make sure conn was checked out of pool
+	stat := c.pool.Stat()
+	total, available := stat.TotalConns(), stat.IdleConns()
+	if want := total - 1; available != want {
+		t.Errorf("want available=%d, got %d", want, available)
+	}
 
-    if err = j.Delete(); err != nil {
-        t.Fatal(err)
-    }
+	if err = j.Delete(); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestLockJobAlreadyLocked(t *testing.T) {
-    c := openTestClient(t)
-    defer closePool(c.pool)
+	c := openTestClient(t)
+	defer closePool(c.pool)
 
-    if err := c.Enqueue(&Job{Type: "MyJob"}); err != nil {
-        t.Fatal(err)
-    }
+	if err := c.Enqueue(&Job{Type: "MyJob"}); err != nil {
+		t.Fatal(err)
+	}
 
-    j, err := c.LockJob("")
-    if err != nil {
-        t.Fatal(err)
-    }
-    if j == nil {
-        t.Fatal("wanted job, got none")
-    }
-    defer j.Done()
+	j, err := c.LockJob("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if j == nil {
+		t.Fatal("wanted job, got none")
+	}
+	defer j.Done()
 
-    j2, err := c.LockJob("")
-    if err != nil {
-        t.Fatal(err)
-    }
-    if j2 != nil {
-        defer j2.Done()
-        t.Fatalf("wanted no job, got %+v", j2)
-    }
+	j2, err := c.LockJob("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if j2 != nil {
+		defer j2.Done()
+		t.Fatalf("wanted no job, got %+v", j2)
+	}
 }
 
 func TestLockJobNoJob(t *testing.T) {
-    c := openTestClient(t)
-    defer closePool(c.pool)
+	c := openTestClient(t)
+	defer closePool(c.pool)
 
-    j, err := c.LockJob("")
-    if err != nil {
-        t.Fatal(err)
-    }
-    if j != nil {
-        t.Errorf("want no job, got %v", j)
-    }
+	j, err := c.LockJob("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if j != nil {
+		t.Errorf("want no job, got %v", j)
+	}
 }
 
 func TestLockJobCustomQueue(t *testing.T) {
-    c := openTestClient(t)
-    defer closePool(c.pool)
+	c := openTestClient(t)
+	defer closePool(c.pool)
 
-    if err := c.Enqueue(&Job{Type: "MyJob", Queue: "extra_priority"}); err != nil {
-        t.Fatal(err)
-    }
+	if err := c.Enqueue(&Job{Type: "MyJob", Queue: "extra_priority"}); err != nil {
+		t.Fatal(err)
+	}
 
-    j, err := c.LockJob("")
-    if err != nil {
-        t.Fatal(err)
-    }
-    if j != nil {
-        j.Done()
-        t.Errorf("expected no job to be found with empty queue name, got %+v", j)
-    }
+	j, err := c.LockJob("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if j != nil {
+		j.Done()
+		t.Errorf("expected no job to be found with empty queue name, got %+v", j)
+	}
 
-    j, err = c.LockJob("extra_priority")
-    if err != nil {
-        t.Fatal(err)
-    }
-    defer j.Done()
+	j, err = c.LockJob("extra_priority")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer j.Done()
 
-    if j == nil {
-        t.Fatal("wanted job, got none")
-    }
+	if j == nil {
+		t.Fatal("wanted job, got none")
+	}
 
-    if err = j.Delete(); err != nil {
-        t.Fatal(err)
-    }
+	if err = j.Delete(); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestJobConn(t *testing.T) {
-    c := openTestClient(t)
-    defer closePool(c.pool)
+	c := openTestClient(t)
+	defer closePool(c.pool)
 
-    if err := c.Enqueue(&Job{Type: "MyJob"}); err != nil {
-        t.Fatal(err)
-    }
+	if err := c.Enqueue(&Job{Type: "MyJob"}); err != nil {
+		t.Fatal(err)
+	}
 
-    j, err := c.LockJob("")
-    if err != nil {
-        t.Fatal(err)
-    }
-    if j == nil {
-        t.Fatal("wanted job, got none")
-    }
-    defer j.Done()
+	j, err := c.LockJob("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if j == nil {
+		t.Fatal("wanted job, got none")
+	}
+	defer j.Done()
 
-    if conn := j.Conn(); conn != j.conn {
-        t.Errorf("want %+v, got %+v", j.conn, conn)
-    }
+	if conn := j.Conn(); conn != j.conn {
+		t.Errorf("want %+v, got %+v", j.conn, conn)
+	}
 }
 
 func TestJobConnRace(t *testing.T) {
-    c := openTestClient(t)
-    defer closePool(c.pool)
+	c := openTestClient(t)
+	defer closePool(c.pool)
 
-    if err := c.Enqueue(&Job{Type: "MyJob"}); err != nil {
-        t.Fatal(err)
-    }
+	if err := c.Enqueue(&Job{Type: "MyJob"}); err != nil {
+		t.Fatal(err)
+	}
 
-    j, err := c.LockJob("")
-    if err != nil {
-        t.Fatal(err)
-    }
-    if j == nil {
-        t.Fatal("wanted job, got none")
-    }
-    defer j.Done()
+	j, err := c.LockJob("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if j == nil {
+		t.Fatal("wanted job, got none")
+	}
+	defer j.Done()
 
-    var wg sync.WaitGroup
-    wg.Add(2)
+	var wg sync.WaitGroup
+	wg.Add(2)
 
-    // call Conn and Done in different goroutines to make sure they are safe from
-    // races.
-    go func() {
-        _ = j.Conn()
-        wg.Done()
-    }()
-    go func() {
-        j.Done()
-        wg.Done()
-    }()
-    wg.Wait()
+	// call Conn and Done in different goroutines to make sure they are safe from
+	// races.
+	go func() {
+		_ = j.Conn()
+		wg.Done()
+	}()
+	go func() {
+		j.Done()
+		wg.Done()
+	}()
+	wg.Wait()
 }
 
 // Test the race condition in LockJob
 func TestLockJobAdvisoryRace(t *testing.T) {
-    c := openTestClientMaxConns(t, 2)
-    defer closePool(c.pool)
+	c := openTestClientMaxConns(t, 2)
+	defer closePool(c.pool)
 
-    // *pgx.ConnPool doesn't support pools of only one connection.  Make sure
-    // the other one is busy so we know which backend will be used by LockJob
-    // below.
-    conn, err := c.pool.Acquire(context.Background())
-    if err != nil {
-        t.Fatal(err)
-    }
-    defer conn.Release()
+	// *pgx.ConnPool doesn't support pools of only one connection.  Make sure
+	// the other one is busy so we know which backend will be used by LockJob
+	// below.
+	conn, err := c.pool.Acquire(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Release()
 
-    // We use two jobs: the first one is concurrently deleted, and the second
-    // one is returned by LockJob after recovering from the race condition.
-    for i := 0; i < 2; i++ {
-        if err := c.Enqueue(&Job{Type: "MyJob"}); err != nil {
-            t.Fatal(err)
-        }
-    }
+	// We use two jobs: the first one is concurrently deleted, and the second
+	// one is returned by LockJob after recovering from the race condition.
+	for i := 0; i < 2; i++ {
+		if err := c.Enqueue(&Job{Type: "MyJob"}); err != nil {
+			t.Fatal(err)
+		}
+	}
 
-    // helper functions
-    newConn := func() *pgx.Conn {
-        conn, err := pgx.Connect(context.Background(), testConnConfig.ConnString())
-        if err != nil {
-            panic(err)
-        }
-        return conn
-    }
-    getBackendPID := func(conn *pgx.Conn) int32 {
-        var backendPID int32
-        err := conn.QueryRow(context.Background(), `
+	// helper functions
+	newConn := func() *pgx.Conn {
+		conn, err := pgx.Connect(context.Background(), testConnConfig.ConnString())
+		if err != nil {
+			panic(err)
+		}
+		return conn
+	}
+	getBackendPID := func(conn *pgx.Conn) int32 {
+		var backendPID int32
+		err := conn.QueryRow(context.Background(), `
 			SELECT pg_backend_pid()
 		`).Scan(&backendPID)
-        if err != nil {
-            panic(err)
-        }
-        return backendPID
-    }
-    waitUntilBackendIsWaiting := func(backendPID int32, name string) {
-        conn := newConn()
-        i := 0
-        for {
-            var waiting bool
-            err := conn.QueryRow(context.Background(), `SELECT wait_event is not null from pg_stat_activity where pid=$1`, backendPID).Scan(&waiting)
-            if err != nil {
-                panic(err)
-            }
+		if err != nil {
+			panic(err)
+		}
+		return backendPID
+	}
+	waitUntilBackendIsWaiting := func(backendPID int32, name string) {
+		conn := newConn()
+		i := 0
+		for {
+			var waiting bool
+			err := conn.QueryRow(context.Background(), `SELECT wait_event is not null from pg_stat_activity where pid=$1`, backendPID).Scan(&waiting)
+			if err != nil {
+				panic(err)
+			}
 
-            if waiting {
-                break
-            } else {
-                i++
-                if i >= 10000/50 {
-                    panic(fmt.Sprintf("timed out while waiting for %s", name))
-                }
+			if waiting {
+				break
+			} else {
+				i++
+				if i >= 10000/50 {
+					panic(fmt.Sprintf("timed out while waiting for %s", name))
+				}
 
-                time.Sleep(50 * time.Millisecond)
-            }
-        }
+				time.Sleep(50 * time.Millisecond)
+			}
+		}
 
-    }
+	}
 
-    // Reproducing the race condition is a bit tricky.  The idea is to form a
-    // lock queue on the relation that looks like this:
-    //
-    //   AccessExclusive <- AccessShare  <- AccessExclusive ( <- AccessShare )
-    //
-    // where the leftmost AccessShare lock is the one implicitly taken by the
-    // sqlLockJob query.  Once we release the leftmost AccessExclusive lock
-    // without releasing the rightmost one, the session holding the rightmost
-    // AccessExclusiveLock can run the necessary DELETE before the sqlCheckJob
-    // query runs (since it'll be blocked behind the rightmost AccessExclusive
-    // Lock).
-    //
-    deletedJobIDChan := make(chan int64, 1)
-    lockJobBackendIDChan := make(chan int32)
-    secondAccessExclusiveBackendIDChan := make(chan int32)
+	// Reproducing the race condition is a bit tricky.  The idea is to form a
+	// lock queue on the relation that looks like this:
+	//
+	//   AccessExclusive <- AccessShare  <- AccessExclusive ( <- AccessShare )
+	//
+	// where the leftmost AccessShare lock is the one implicitly taken by the
+	// sqlLockJob query.  Once we release the leftmost AccessExclusive lock
+	// without releasing the rightmost one, the session holding the rightmost
+	// AccessExclusiveLock can run the necessary DELETE before the sqlCheckJob
+	// query runs (since it'll be blocked behind the rightmost AccessExclusive
+	// Lock).
+	//
+	deletedJobIDChan := make(chan int64, 1)
+	lockJobBackendIDChan := make(chan int32)
+	secondAccessExclusiveBackendIDChan := make(chan int32)
 
-    go func() {
-        conn := newConn()
-        defer conn.Close(context.Background())
+	go func() {
+		conn := newConn()
+		defer conn.Close(context.Background())
 
-        tx, err := conn.Begin(context.Background())
-        if err != nil {
-            panic(err)
-        }
-        _, err = tx.Exec(context.Background(), `LOCK TABLE que_jobs IN ACCESS EXCLUSIVE MODE`)
-        if err != nil {
-            panic(err)
-        }
+		tx, err := conn.Begin(context.Background())
+		if err != nil {
+			panic(err)
+		}
+		_, err = tx.Exec(context.Background(), `LOCK TABLE que_jobs IN ACCESS EXCLUSIVE MODE`)
+		if err != nil {
+			panic(err)
+		}
 
-        // first wait for LockJob to appear behind us
-        backendID := <-lockJobBackendIDChan
-        waitUntilBackendIsWaiting(backendID, "LockJob")
+		// first wait for LockJob to appear behind us
+		backendID := <-lockJobBackendIDChan
+		waitUntilBackendIsWaiting(backendID, "LockJob")
 
-        // then for the AccessExclusive lock to appear behind that one
-        backendID = <-secondAccessExclusiveBackendIDChan
-        waitUntilBackendIsWaiting(backendID, "second access exclusive lock")
+		// then for the AccessExclusive lock to appear behind that one
+		backendID = <-secondAccessExclusiveBackendIDChan
+		waitUntilBackendIsWaiting(backendID, "second access exclusive lock")
 
-        err = tx.Rollback(context.Background())
-        if err != nil {
-            panic(err)
-        }
-    }()
+		err = tx.Rollback(context.Background())
+		if err != nil {
+			panic(err)
+		}
+	}()
 
-    go func() {
-        conn := newConn()
-        defer conn.Close(context.Background())
+	go func() {
+		conn := newConn()
+		defer conn.Close(context.Background())
 
-        // synchronization point
-        secondAccessExclusiveBackendIDChan <- getBackendPID(conn)
+		// synchronization point
+		secondAccessExclusiveBackendIDChan <- getBackendPID(conn)
 
-        tx, err := conn.Begin(context.Background())
-        if err != nil {
-            panic(err)
-        }
-        _, err = tx.Exec(context.Background(), `LOCK TABLE que_jobs IN ACCESS EXCLUSIVE MODE`)
-        if err != nil {
-            panic(err)
-        }
+		tx, err := conn.Begin(context.Background())
+		if err != nil {
+			panic(err)
+		}
+		_, err = tx.Exec(context.Background(), `LOCK TABLE que_jobs IN ACCESS EXCLUSIVE MODE`)
+		if err != nil {
+			panic(err)
+		}
 
-        // Fake a concurrent transaction grabbing the job
-        var jid int64
-        err = tx.QueryRow(context.Background(), `
+		// Fake a concurrent transaction grabbing the job
+		var jid int64
+		err = tx.QueryRow(context.Background(), `
 			DELETE FROM que_jobs
 			WHERE job_id =
 				(SELECT min(job_id)
 				 FROM que_jobs)
 			RETURNING job_id
 		`).Scan(&jid)
-        if err != nil {
-            panic(err)
-        }
+		if err != nil {
+			panic(err)
+		}
 
-        deletedJobIDChan <- jid
+		deletedJobIDChan <- jid
 
-        err = tx.Commit(context.Background())
-        if err != nil {
-            panic(err)
-        }
-    }()
+		err = tx.Commit(context.Background())
+		if err != nil {
+			panic(err)
+		}
+	}()
 
-    conn, err = c.pool.Acquire(context.Background())
-    if err != nil {
-        panic(err)
-    }
-    ourBackendID := getBackendPID(conn.Conn())
-    conn.Release()
+	conn, err = c.pool.Acquire(context.Background())
+	if err != nil {
+		panic(err)
+	}
+	ourBackendID := getBackendPID(conn.Conn())
+	conn.Release()
 
-    // synchronization point
-    lockJobBackendIDChan <- ourBackendID
+	// synchronization point
+	lockJobBackendIDChan <- ourBackendID
 
-    job, err := c.LockJob("")
-    if err != nil {
-        panic(err)
-    }
-    defer job.Done()
+	job, err := c.LockJob("")
+	if err != nil {
+		panic(err)
+	}
+	defer job.Done()
 
-    deletedJobID := <-deletedJobIDChan
+	deletedJobID := <-deletedJobIDChan
 
-    t.Logf("Got id %d", job.ID)
-    t.Logf("Concurrently deleted id %d", deletedJobID)
+	t.Logf("Got id %d", job.ID)
+	t.Logf("Concurrently deleted id %d", deletedJobID)
 
-    if deletedJobID >= job.ID {
-        t.Fatalf("deleted job id %d must be smaller than job.ID %d", deletedJobID, job.ID)
-    }
+	if deletedJobID >= job.ID {
+		t.Fatalf("deleted job id %d must be smaller than job.ID %d", deletedJobID, job.ID)
+	}
 }
 
 func TestJobDelete(t *testing.T) {
-    c := openTestClient(t)
-    defer closePool(c.pool)
+	c := openTestClient(t)
+	defer closePool(c.pool)
 
-    if err := c.Enqueue(&Job{Type: "MyJob"}); err != nil {
-        t.Fatal(err)
-    }
+	if err := c.Enqueue(&Job{Type: "MyJob"}); err != nil {
+		t.Fatal(err)
+	}
 
-    j, err := c.LockJob("")
-    if err != nil {
-        t.Fatal(err)
-    }
-    if j == nil {
-        t.Fatal("wanted job, got none")
-    }
-    defer j.Done()
+	j, err := c.LockJob("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if j == nil {
+		t.Fatal("wanted job, got none")
+	}
+	defer j.Done()
 
-    if err = j.Delete(); err != nil {
-        t.Fatal(err)
-    }
+	if err = j.Delete(); err != nil {
+		t.Fatal(err)
+	}
 
-    // make sure job was deleted
-    j2, err := findOneJob(c.pool)
-    if err != nil {
-        t.Fatal(err)
-    }
-    if j2 != nil {
-        t.Errorf("job was not deleted: %+v", j2)
-    }
+	// make sure job was deleted
+	j2, err := findOneJob(c.pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if j2 != nil {
+		t.Errorf("job was not deleted: %+v", j2)
+	}
 }
 
 func TestJobDone(t *testing.T) {
-    c := openTestClient(t)
-    defer closePool(c.pool)
+	c := openTestClient(t)
+	defer closePool(c.pool)
 
-    if err := c.Enqueue(&Job{Type: "MyJob"}); err != nil {
-        t.Fatal(err)
-    }
+	if err := c.Enqueue(&Job{Type: "MyJob"}); err != nil {
+		t.Fatal(err)
+	}
 
-    j, err := c.LockJob("")
-    if err != nil {
-        t.Fatal(err)
-    }
-    if j == nil {
-        t.Fatal("wanted job, got none")
-    }
+	j, err := c.LockJob("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if j == nil {
+		t.Fatal("wanted job, got none")
+	}
 
-    j.Done()
+	j.Done()
 
-    // make sure conn and pool were cleared
-    if j.conn != nil {
-        t.Errorf("want nil conn, got %+v", j.conn)
-    }
-    if j.pool != nil {
-        t.Errorf("want nil pool, got %+v", j.pool)
-    }
+	// make sure conn and pool were cleared
+	if j.conn != nil {
+		t.Errorf("want nil conn, got %+v", j.conn)
+	}
+	if j.pool != nil {
+		t.Errorf("want nil pool, got %+v", j.pool)
+	}
 
-    // make sure lock was released
-    var count int64
-    query := "SELECT count(*) FROM pg_locks WHERE locktype=$1 AND objid=$2::bigint"
-    if err = c.pool.QueryRow(context.Background(),query, "advisory", j.ID).Scan(&count); err != nil {
-        t.Fatal(err)
-    }
-    if count != 0 {
-        t.Error("advisory lock was not released")
-    }
+	// make sure lock was released
+	var count int64
+	query := "SELECT count(*) FROM pg_locks WHERE locktype=$1 AND objid=$2::bigint"
+	if err = c.pool.QueryRow(context.Background(), query, "advisory", j.ID).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Error("advisory lock was not released")
+	}
 
-    // make sure conn was returned to pool
-    stat := c.pool.Stat()
-    total, available := stat.TotalConns(), stat.IdleConns()
-    if total != available {
-        t.Errorf("want available=total, got available=%d total=%d", available, total)
-    }
+	// make sure conn was returned to pool
+	stat := c.pool.Stat()
+	total, available := stat.TotalConns(), stat.IdleConns()
+	if total != available {
+		t.Errorf("want available=total, got available=%d total=%d", available, total)
+	}
 }
 
 func TestJobDoneMultiple(t *testing.T) {
-    c := openTestClient(t)
-    defer closePool(c.pool)
+	c := openTestClient(t)
+	defer closePool(c.pool)
 
-    if err := c.Enqueue(&Job{Type: "MyJob"}); err != nil {
-        t.Fatal(err)
-    }
+	if err := c.Enqueue(&Job{Type: "MyJob"}); err != nil {
+		t.Fatal(err)
+	}
 
-    j, err := c.LockJob("")
-    if err != nil {
-        t.Fatal(err)
-    }
-    if j == nil {
-        t.Fatal("wanted job, got none")
-    }
+	j, err := c.LockJob("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if j == nil {
+		t.Fatal("wanted job, got none")
+	}
 
-    j.Done()
-    // try calling Done() again
-    j.Done()
+	j.Done()
+	// try calling Done() again
+	j.Done()
 }
 
 func TestJobDeleteFromTx(t *testing.T) {
-    c := openTestClient(t)
-    defer closePool(c.pool)
+	c := openTestClient(t)
+	defer closePool(c.pool)
 
-    if err := c.Enqueue(&Job{Type: "MyJob"}); err != nil {
-        t.Fatal(err)
-    }
+	if err := c.Enqueue(&Job{Type: "MyJob"}); err != nil {
+		t.Fatal(err)
+	}
 
-    j, err := c.LockJob("")
-    if err != nil {
-        t.Fatal(err)
-    }
-    if j == nil {
-        t.Fatal("wanted job, got none")
-    }
+	j, err := c.LockJob("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if j == nil {
+		t.Fatal("wanted job, got none")
+	}
 
-    // get the job's database connection
-    conn := j.Conn()
-    if conn == nil {
-        t.Fatal("wanted conn, got nil")
-    }
+	// get the job's database connection
+	conn := j.Conn()
+	if conn == nil {
+		t.Fatal("wanted conn, got nil")
+	}
 
-    // start a transaction
-    tx, err := conn.Begin(context.Background())
-    if err != nil {
-        t.Fatal(err)
-    }
+	// start a transaction
+	tx, err := conn.Begin(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
 
-    // delete the job
-    if err = j.Delete(); err != nil {
-        t.Fatal(err)
-    }
+	// delete the job
+	if err = j.Delete(); err != nil {
+		t.Fatal(err)
+	}
 
-    if err = tx.Commit(context.Background()); err != nil {
-        t.Fatal(err)
-    }
+	if err = tx.Commit(context.Background()); err != nil {
+		t.Fatal(err)
+	}
 
-    // mark as done
-    j.Done()
+	// mark as done
+	j.Done()
 
-    // make sure the job is gone
-    j2, err := findOneJob(c.pool)
-    if err != nil {
-        t.Fatal(err)
-    }
+	// make sure the job is gone
+	j2, err := findOneJob(c.pool)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-    if j2 != nil {
-        t.Errorf("wanted no job, got %+v", j2)
-    }
+	if j2 != nil {
+		t.Errorf("wanted no job, got %+v", j2)
+	}
 }
 
 func TestJobDeleteFromTxRollback(t *testing.T) {
-    c := openTestClient(t)
-    defer closePool(c.pool)
+	c := openTestClient(t)
+	defer closePool(c.pool)
 
-    if err := c.Enqueue(&Job{Type: "MyJob"}); err != nil {
-        t.Fatal(err)
-    }
+	if err := c.Enqueue(&Job{Type: "MyJob"}); err != nil {
+		t.Fatal(err)
+	}
 
-    j1, err := c.LockJob("")
-    if err != nil {
-        t.Fatal(err)
-    }
-    if j1 == nil {
-        t.Fatal("wanted job, got none")
-    }
+	j1, err := c.LockJob("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if j1 == nil {
+		t.Fatal("wanted job, got none")
+	}
 
-    // get the job's database connection
-    conn := j1.Conn()
-    if conn == nil {
-        t.Fatal("wanted conn, got nil")
-    }
+	// get the job's database connection
+	conn := j1.Conn()
+	if conn == nil {
+		t.Fatal("wanted conn, got nil")
+	}
 
-    // start a transaction
-    tx, err := conn.Begin(context.Background())
-    if err != nil {
-        t.Fatal(err)
-    }
+	// start a transaction
+	tx, err := conn.Begin(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
 
-    // delete the job
-    if err = j1.Delete(); err != nil {
-        t.Fatal(err)
-    }
+	// delete the job
+	if err = j1.Delete(); err != nil {
+		t.Fatal(err)
+	}
 
-    if err = tx.Rollback(context.Background()); err != nil {
-        t.Fatal(err)
-    }
+	if err = tx.Rollback(context.Background()); err != nil {
+		t.Fatal(err)
+	}
 
-    // mark as done
-    j1.Done()
+	// mark as done
+	j1.Done()
 
-    // make sure the job still exists and matches j1
-    j2, err := findOneJob(c.pool)
-    if err != nil {
-        t.Fatal(err)
-    }
+	// make sure the job still exists and matches j1
+	j2, err := findOneJob(c.pool)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-    if j1.ID != j2.ID {
-        t.Errorf("want job %d, got %d", j1.ID, j2.ID)
-    }
+	if j1.ID != j2.ID {
+		t.Errorf("want job %d, got %d", j1.ID, j2.ID)
+	}
 }
 
 func TestJobError(t *testing.T) {
-    c := openTestClient(t)
-    defer closePool(c.pool)
+	c := openTestClient(t)
+	defer closePool(c.pool)
 
-    if err := c.Enqueue(&Job{Type: "MyJob"}); err != nil {
-        t.Fatal(err)
-    }
+	if err := c.Enqueue(&Job{Type: "MyJob"}); err != nil {
+		t.Fatal(err)
+	}
 
-    j, err := c.LockJob("")
-    if err != nil {
-        t.Fatal(err)
-    }
-    if j == nil {
-        t.Fatal("wanted job, got none")
-    }
-    defer j.Done()
+	j, err := c.LockJob("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if j == nil {
+		t.Fatal("wanted job, got none")
+	}
+	defer j.Done()
 
-    msg := "world\nended"
-    if err = j.Error(msg); err != nil {
-        t.Fatal(err)
-    }
-    j.Done()
+	msg := "world\nended"
+	if err = j.Error(msg); err != nil {
+		t.Fatal(err)
+	}
+	j.Done()
 
-    // make sure job was not deleted
-    j2, err := findOneJob(c.pool)
-    if err != nil {
-        t.Fatal(err)
-    }
-    if j2 == nil {
-        t.Fatal("job was not found")
-    }
-    defer j2.Done()
+	// make sure job was not deleted
+	j2, err := findOneJob(c.pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if j2 == nil {
+		t.Fatal("job was not found")
+	}
+	defer j2.Done()
 
-    if j2.LastError.Status == pgtype.Null || j2.LastError.String != msg {
-        t.Errorf("want LastError=%q, got %q", msg, j2.LastError.String)
-    }
-    if j2.ErrorCount != 1 {
-        t.Errorf("want ErrorCount=%d, got %d", 1, j2.ErrorCount)
-    }
+	if j2.LastError.Status == pgtype.Null || j2.LastError.String != msg {
+		t.Errorf("want LastError=%q, got %q", msg, j2.LastError.String)
+	}
+	if j2.ErrorCount != 1 {
+		t.Errorf("want ErrorCount=%d, got %d", 1, j2.ErrorCount)
+	}
 
-    // make sure lock was released
-    var count int64
-    query := "SELECT count(*) FROM pg_locks WHERE locktype=$1 AND objid=$2::bigint"
-    if err = c.pool.QueryRow(context.Background(), query, "advisory", j.ID).Scan(&count); err != nil {
-        t.Fatal(err)
-    }
-    if count != 0 {
-        t.Error("advisory lock was not released")
-    }
+	// make sure lock was released
+	var count int64
+	query := "SELECT count(*) FROM pg_locks WHERE locktype=$1 AND objid=$2::bigint"
+	if err = c.pool.QueryRow(context.Background(), query, "advisory", j.ID).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Error("advisory lock was not released")
+	}
 
-    // make sure conn was returned to pool
-    stat := c.pool.Stat()
-    total, available := stat.TotalConns(), stat.IdleConns()
-    if total != available {
-        t.Errorf("want available=total, got available=%d total=%d", available, total)
-    }
+	// make sure conn was returned to pool
+	stat := c.pool.Stat()
+	total, available := stat.TotalConns(), stat.IdleConns()
+	if total != available {
+		t.Errorf("want available=total, got available=%d total=%d", available, total)
+	}
+}
+
+func TestJobUpdate(t *testing.T) {
+
+	c := openTestClient(t)
+	defer closePool(c.pool)
+
+	if err := c.Enqueue(&Job{Type: "MyJobToReschedule"}); err != nil {
+		t.Fatal(err)
+	}
+
+	j, err := c.LockJob("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer j.Done()
+
+	if j == nil {
+		t.Fatal("wanted job, got none")
+	}
+
+	// add args and reschedule
+	j.Args = []byte("{\"foo\":\"bar\"}")
+	j.Type = "MyJobToReschedule2"
+	j.Reschedule(time.Now().Add(10 * time.Minute))
+
+	err = j.Finalize()
+	if err != nil {
+		t.Fatal(err)
+	}
+	j.Done()
+
+	j2, err := findOneJob(c.pool)
+	defer j2.Done()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if j2 == nil {
+		t.Fatal("wanted updated job, got none")
+	}
+
+	if j.ID != j2.ID {
+		t.Fatal("expected updated job with same ID")
+	}
+
+	if j.Type != j2.Type {
+		t.Fatal("expected updated job with same type")
+	}
+
+	if string(j.Args) != string(j2.Args) {
+		t.Fatal("expected updated job with new args")
+	}
+
+	if j.RunAt.UTC() != j2.RunAt.UTC() {
+		t.Fatal("expected updated job with new runAt")
+	}
+
+}
+
+func TestJobErrorUpdate(t *testing.T) {
+
+	c := openTestClient(t)
+	defer closePool(c.pool)
+
+	if err := c.Enqueue(&Job{Type: "MyJobToReschedule"}); err != nil {
+		t.Fatal(err)
+	}
+
+	j, err := c.LockJob("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer j.Done()
+
+	if j == nil {
+		t.Fatal("wanted job, got none")
+	}
+
+	msg := "A nice day for an error!"
+	if err = j.Error(msg); err != nil {
+		t.Fatal(err)
+	}
+	j.Done()
+
+	// delay so lock job picks
+	// up the previous job
+	time.Sleep(4 * time.Second)
+
+	// use lock job here so we pick up
+	// the job.pool and conn for the update
+	j2, err := c.LockJob("")
+	defer j2.Done()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if j.ErrorCount+1 != j2.ErrorCount {
+		t.Fatal("expected updated job with a higher error count")
+	}
+
+	if j2.LastError.Status != pgtype.Present {
+		t.Fatal("expected updated job with a last error")
+	}
+
+	if j2.LastError.Get().(string) != msg {
+		t.Fatalf("expected updated job with a last error=%s", msg)
+	}
+
+	// reset LastError
+	j2.ResetError()
+	j2.Reschedule(time.Now().Add(10 * time.Minute))
+	j2.Finalize()
+	j2.Done()
+
+	j3, err := findOneJob(c.pool)
+	defer j3.Done()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// error count should be 0 and lasterror null
+	if j3.ErrorCount != 0 {
+		t.Fatal("expected updated job zero error count")
+	}
+
+	if j3.LastError.Status != pgtype.Null {
+		t.Fatal("expected updated job with no last error")
+	}
+
+	if j2.RunAt.UTC() != j3.RunAt.UTC() {
+		t.Fatal("expected updated job with new runAt")
+	}
+
 }

--- a/worker.go
+++ b/worker.go
@@ -122,9 +122,10 @@ func (w *Worker) WorkOne() (didWork bool) {
 		return
 	}
 
-	if err = j.Delete(); err != nil {
-		log.Printf("attempting to delete job %d: %v", j.ID, err)
+	if err = j.Finalize(); err != nil {
+		log.Printf("attempting to finalize job %d: %v", j.ID, err)
 	}
+
 	log.Printf("event=job_worked job_id=%d job_type=%s", j.ID, j.Type)
 	return
 }

--- a/worker_test.go
+++ b/worker_test.go
@@ -1,252 +1,252 @@
 package que
 
 import (
-    "context"
-    "fmt"
-    "io/ioutil"
-    "log"
-    "os"
-    "strings"
-    "testing"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+	"testing"
 
-    "github.com/jackc/pgtype"
+	"github.com/jackc/pgtype"
 )
 
 func init() {
-    log.SetOutput(ioutil.Discard)
+	log.SetOutput(ioutil.Discard)
 }
 
 func TestWorkerWorkOne(t *testing.T) {
-    c := openTestClient(t)
-    defer closePool(c.pool)
+	c := openTestClient(t)
+	defer closePool(c.pool)
 
-    success := false
-    wm := WorkMap{
-        "MyJob": func(j *Job) error {
-            success = true
-            return nil
-        },
-    }
-    w := NewWorker(c, wm)
+	success := false
+	wm := WorkMap{
+		"MyJob": func(j *Job) error {
+			success = true
+			return nil
+		},
+	}
+	w := NewWorker(c, wm)
 
-    didWork := w.WorkOne()
-    if didWork {
-        t.Errorf("want didWork=false when no job was queued")
-    }
+	didWork := w.WorkOne()
+	if didWork {
+		t.Errorf("want didWork=false when no job was queued")
+	}
 
-    if err := c.Enqueue(&Job{Type: "MyJob"}); err != nil {
-        t.Fatal(err)
-    }
+	if err := c.Enqueue(&Job{Type: "MyJob"}); err != nil {
+		t.Fatal(err)
+	}
 
-    didWork = w.WorkOne()
-    if !didWork {
-        t.Errorf("want didWork=true")
-    }
-    if !success {
-        t.Errorf("want success=true")
-    }
+	didWork = w.WorkOne()
+	if !didWork {
+		t.Errorf("want didWork=true")
+	}
+	if !success {
+		t.Errorf("want success=true")
+	}
 }
 
 func TestWorkerShutdown(t *testing.T) {
-    c := openTestClient(t)
-    defer closePool(c.pool)
+	c := openTestClient(t)
+	defer closePool(c.pool)
 
-    w := NewWorker(c, WorkMap{})
-    finished := false
-    go func() {
-        w.Work()
-        finished = true
-    }()
-    w.Shutdown()
-    if !finished {
-        t.Errorf("want finished=true")
-    }
-    if !w.done {
-        t.Errorf("want w.done=true")
-    }
+	w := NewWorker(c, WorkMap{})
+	finished := false
+	go func() {
+		w.Work()
+		finished = true
+	}()
+	w.Shutdown()
+	if !finished {
+		t.Errorf("want finished=true")
+	}
+	if !w.done {
+		t.Errorf("want w.done=true")
+	}
 }
 
 func BenchmarkWorker(b *testing.B) {
-    c := openTestClient(b)
-    log.SetOutput(ioutil.Discard)
-    defer func() {
-        log.SetOutput(os.Stdout)
-    }()
-    defer closePool(c.pool)
+	c := openTestClient(b)
+	log.SetOutput(ioutil.Discard)
+	defer func() {
+		log.SetOutput(os.Stdout)
+	}()
+	defer closePool(c.pool)
 
-    w := NewWorker(c, WorkMap{"Nil": nilWorker})
+	w := NewWorker(c, WorkMap{"Nil": nilWorker})
 
-    for i := 0; i < b.N; i++ {
-        if err := c.Enqueue(&Job{Type: "Nil"}); err != nil {
-            log.Fatal(err)
-        }
-    }
+	for i := 0; i < b.N; i++ {
+		if err := c.Enqueue(&Job{Type: "Nil"}); err != nil {
+			log.Fatal(err)
+		}
+	}
 
-    b.ResetTimer()
-    for i := 0; i < b.N; i++ {
-        w.WorkOne()
-    }
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		w.WorkOne()
+	}
 }
 
 func nilWorker(j *Job) error {
-    return nil
+	return nil
 }
 
 func TestWorkerWorkReturnsError(t *testing.T) {
-    c := openTestClient(t)
-    defer closePool(c.pool)
+	c := openTestClient(t)
+	defer closePool(c.pool)
 
-    called := 0
-    wm := WorkMap{
-        "MyJob": func(j *Job) error {
-            called++
-            return fmt.Errorf("the error msg")
-        },
-    }
-    w := NewWorker(c, wm)
+	called := 0
+	wm := WorkMap{
+		"MyJob": func(j *Job) error {
+			called++
+			return fmt.Errorf("the error msg")
+		},
+	}
+	w := NewWorker(c, wm)
 
-    didWork := w.WorkOne()
-    if didWork {
-        t.Errorf("want didWork=false when no job was queued")
-    }
+	didWork := w.WorkOne()
+	if didWork {
+		t.Errorf("want didWork=false when no job was queued")
+	}
 
-    if err := c.Enqueue(&Job{Type: "MyJob"}); err != nil {
-        t.Fatal(err)
-    }
+	if err := c.Enqueue(&Job{Type: "MyJob"}); err != nil {
+		t.Fatal(err)
+	}
 
-    didWork = w.WorkOne()
-    if !didWork {
-        t.Errorf("want didWork=true")
-    }
-    if called != 1 {
-        t.Errorf("want called=1 was: %d", called)
-    }
+	didWork = w.WorkOne()
+	if !didWork {
+		t.Errorf("want didWork=true")
+	}
+	if called != 1 {
+		t.Errorf("want called=1 was: %d", called)
+	}
 
-    tx, err := c.pool.Begin(context.Background())
-    if err != nil {
-        t.Fatal(err)
-    }
-    defer tx.Rollback(context.Background())
+	tx, err := c.pool.Begin(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback(context.Background())
 
-    j, err := findOneJob(tx)
-    if err != nil {
-        t.Fatal(err)
-    }
-    if j.ErrorCount != 1 {
-        t.Errorf("want ErrorCount=1 was %d", j.ErrorCount)
-    }
-    if j.LastError.Status == pgtype.Null {
-        t.Errorf("want LastError IS NOT NULL")
-    }
-    if j.LastError.String != "the error msg" {
-        t.Errorf("want LastError=\"the error msg\" was: %q", j.LastError.String)
-    }
+	j, err := findOneJob(tx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if j.ErrorCount != 1 {
+		t.Errorf("want ErrorCount=1 was %d", j.ErrorCount)
+	}
+	if j.LastError.Status == pgtype.Null {
+		t.Errorf("want LastError IS NOT NULL")
+	}
+	if j.LastError.String != "the error msg" {
+		t.Errorf("want LastError=\"the error msg\" was: %q", j.LastError.String)
+	}
 }
 
 func TestWorkerWorkRescuesPanic(t *testing.T) {
-    c := openTestClient(t)
-    defer closePool(c.pool)
+	c := openTestClient(t)
+	defer closePool(c.pool)
 
-    called := 0
-    wm := WorkMap{
-        "MyJob": func(j *Job) error {
-            called++
-            panic("the panic msg")
-            return nil
-        },
-    }
-    w := NewWorker(c, wm)
+	called := 0
+	wm := WorkMap{
+		"MyJob": func(j *Job) error {
+			called++
+			panic("the panic msg")
+			return nil
+		},
+	}
+	w := NewWorker(c, wm)
 
-    if err := c.Enqueue(&Job{Type: "MyJob"}); err != nil {
-        t.Fatal(err)
-    }
+	if err := c.Enqueue(&Job{Type: "MyJob"}); err != nil {
+		t.Fatal(err)
+	}
 
-    w.WorkOne()
-    if called != 1 {
-        t.Errorf("want called=1 was: %d", called)
-    }
+	w.WorkOne()
+	if called != 1 {
+		t.Errorf("want called=1 was: %d", called)
+	}
 
-    tx, err := c.pool.Begin(context.Background())
-    if err != nil {
-        t.Fatal(err)
-    }
-    defer tx.Rollback(context.Background())
+	tx, err := c.pool.Begin(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback(context.Background())
 
-    j, err := findOneJob(tx)
-    if err != nil {
-        t.Fatal(err)
-    }
-    if j.ErrorCount != 1 {
-        t.Errorf("want ErrorCount=1 was %d", j.ErrorCount)
-    }
-    if j.LastError.Status == pgtype.Null {
-        t.Errorf("want LastError IS NOT NULL")
-    }
-    if !strings.Contains(j.LastError.String, "the panic msg\n") {
-        t.Errorf("want LastError contains \"the panic msg\\n\" was: %q", j.LastError.String)
-    }
-    // basic check if a stacktrace is there - not the stacktrace format itself
-    if !strings.Contains(j.LastError.String, "worker.go:") {
-        t.Errorf("want LastError contains \"worker.go:\" was: %q", j.LastError.String)
-    }
-    if !strings.Contains(j.LastError.String, "worker_test.go:") {
-        t.Errorf("want LastError contains \"worker_test.go:\" was: %q", j.LastError.String)
-    }
+	j, err := findOneJob(tx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if j.ErrorCount != 1 {
+		t.Errorf("want ErrorCount=1 was %d", j.ErrorCount)
+	}
+	if j.LastError.Status == pgtype.Null {
+		t.Errorf("want LastError IS NOT NULL")
+	}
+	if !strings.Contains(j.LastError.String, "the panic msg\n") {
+		t.Errorf("want LastError contains \"the panic msg\\n\" was: %q", j.LastError.String)
+	}
+	// basic check if a stacktrace is there - not the stacktrace format itself
+	if !strings.Contains(j.LastError.String, "worker.go:") {
+		t.Errorf("want LastError contains \"worker.go:\" was: %q", j.LastError.String)
+	}
+	if !strings.Contains(j.LastError.String, "worker_test.go:") {
+		t.Errorf("want LastError contains \"worker_test.go:\" was: %q", j.LastError.String)
+	}
 }
 
 func TestWorkerWorkOneTypeNotInMap(t *testing.T) {
-    c := openTestClient(t)
-    defer closePool(c.pool)
+	c := openTestClient(t)
+	defer closePool(c.pool)
 
-    currentConns := c.pool.Stat().TotalConns()
-    availConns := c.pool.Stat().AcquiredConns()
+	currentConns := c.pool.Stat().TotalConns()
+	availConns := c.pool.Stat().AcquiredConns()
 
-    success := false
-    wm := WorkMap{}
-    w := NewWorker(c, wm)
+	success := false
+	wm := WorkMap{}
+	w := NewWorker(c, wm)
 
-    didWork := w.WorkOne()
-    if didWork {
-        t.Errorf("want didWork=false when no job was queued")
-    }
+	didWork := w.WorkOne()
+	if didWork {
+		t.Errorf("want didWork=false when no job was queued")
+	}
 
-    if err := c.Enqueue(&Job{Type: "MyJob"}); err != nil {
-        t.Fatal(err)
-    }
+	if err := c.Enqueue(&Job{Type: "MyJob"}); err != nil {
+		t.Fatal(err)
+	}
 
-    didWork = w.WorkOne()
-    if !didWork {
-        t.Errorf("want didWork=true")
-    }
-    if success {
-        t.Errorf("want success=false")
-    }
+	didWork = w.WorkOne()
+	if !didWork {
+		t.Errorf("want didWork=true")
+	}
+	if success {
+		t.Errorf("want success=false")
+	}
 
-    if currentConns != c.pool.Stat().TotalConns() {
-        t.Errorf("want currentConns euqual: before=%d  after=%d", currentConns, c.pool.Stat().TotalConns())
-    }
-    if availConns != c.pool.Stat().AcquiredConns() {
-        t.Errorf("want availConns euqual: before=%d  after=%d", availConns, c.pool.Stat().AcquiredConns())
-    }
+	if currentConns != c.pool.Stat().TotalConns() {
+		t.Errorf("want currentConns euqual: before=%d  after=%d", currentConns, c.pool.Stat().TotalConns())
+	}
+	if availConns != c.pool.Stat().AcquiredConns() {
+		t.Errorf("want availConns euqual: before=%d  after=%d", availConns, c.pool.Stat().AcquiredConns())
+	}
 
-    tx, err := c.pool.Begin(context.Background())
-    if err != nil {
-        t.Fatal(err)
-    }
-    defer tx.Rollback(context.Background())
+	tx, err := c.pool.Begin(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback(context.Background())
 
-    j, err := findOneJob(tx)
-    if err != nil {
-        t.Fatal(err)
-    }
-    if j.ErrorCount != 1 {
-        t.Errorf("want ErrorCount=1 was %d", j.ErrorCount)
-    }
-    if j.LastError.Status == pgtype.Null {
-        t.Fatal("want non-nil LastError")
-    }
-    if want := "unknown job type: \"MyJob\""; j.LastError.String != want {
-        t.Errorf("want LastError=%q, got %q", want, j.LastError.String)
-    }
+	j, err := findOneJob(tx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if j.ErrorCount != 1 {
+		t.Errorf("want ErrorCount=1 was %d", j.ErrorCount)
+	}
+	if j.LastError.Status == pgtype.Null {
+		t.Fatal("want non-nil LastError")
+	}
+	if want := "unknown job type: \"MyJob\""; j.LastError.String != want {
+		t.Errorf("want LastError=%q, got %q", want, j.LastError.String)
+	}
 
 }


### PR DESCRIPTION
@gadelkareem Since the official repo is slow getting back to us, I thought I would start with your fork to make these changes. 

## Changes

1. This adds the capability to reschedule and update Jobs. The basic idea is we now call `Job.Finalize()` which either updates or deletes the job. One other change I made here is to return the `Job.LastError` from `LockJob` (otherwise, I don't really understand why this stores the last error if you can't use it). So, you now have the option to either preserve the last error or reset the errors before updating.

So, in your worker code, you would just need to do something like this to reuse the same job, again.

```go

func HandleMyJob(job *Job) error {
    // ... 
    if job.ErrorCount > 0 {
        job.ResetError()
    }
    job.Reschedule(time.Now.Add(1 * time.Hour))
    return nil
}
```

2. While working on this, my editor started reformatting the go code whenever I saved. So, I ended up running `gofmt -s -w` across all the untouched files. I can make this a separate PR if that's easier to review. We might want to add running `gofmt` and have the travis test fail if the gofmt finds any changes?